### PR TITLE
📈: Preserve semver range in Renovate update

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   labels: ['deps'],
   commitMessagePrefix: '⬆️: ',
-  extends: ['config:base'],
+  extends: ['config:base', ':preserveSemverRanges'],
   timezone: 'Asia/Tokyo',
   lockFileMaintenance: {
     enabled: true,


### PR DESCRIPTION
## ✅ What's done

- [x] Add [`:preserveSemverRanges`](https://docs.renovatebot.com/presets-default/#preservesemverranges)
---

<!-- 上の区切りまでが、マージされるときにコミットメッセージとして使われます。 -->